### PR TITLE
Fix edge case where .NetIO and .BlockIO return "--"

### DIFF
--- a/check_container_stats_podman.py
+++ b/check_container_stats_podman.py
@@ -168,6 +168,11 @@ def get_container_stats(args, docker_env):
 def convert_to_bytes(inputstr):
     """ converts docker output units to raw bytes """
 
+    if inputstr == "--":
+        # If the container does not bind any ports podman returns "-- / --" as
+        # .NetIO metrics, .BlockIO shows similar behaviour
+        inputstr = '0B'
+
     # Some versions of the "podman" command put a whitespace between value and unit
     # Thus we remove all whitespaces and then separate unit from value
     value = float(findall("[0-9.]+", inputstr.replace(" ", ""))[0])


### PR DESCRIPTION
- `podman stats` returns `--` as .NetIO metric when the container does not bind any ports
- `docker stats` is not affected from this behaviour, it returns `0B / 0B` as .NetIO 
- Fixes #1 
