### PR TITLE
Improved unit detection for "stats" output

### DIFF
--- a/check_container_stats_docker.py
+++ b/check_container_stats_docker.py
@@ -203,7 +203,7 @@ def convert_to_bytes(inputstr):
         value = round(value * 1000000000)
     elif unit == 'MB':
         value = round(value * 1000000)
-    elif unit == 'KB':
+    elif unit in ['KB', 'kB']:
         value = round(value * 1000)
     elif unit == 'B':
         value = round(value)
@@ -213,6 +213,8 @@ def convert_to_bytes(inputstr):
         value = round(value * 1048576)
     elif unit == 'KiB':
         value = round(value * 1024)
+    else:
+        exit_plugin(3, f'Unknown metric unit in "docker stats" output: {unit}', "")
 
     return int(value)
 

--- a/check_container_stats_podman.py
+++ b/check_container_stats_podman.py
@@ -177,7 +177,7 @@ def convert_to_bytes(inputstr):
         value = round(value * 1000000000)
     elif unit == 'MB':
         value = round(value * 1000000)
-    elif unit == 'KB':
+    elif unit in ['KB', 'kB']:
         value = round(value * 1000)
     elif unit == 'B':
         value = round(value)
@@ -187,6 +187,8 @@ def convert_to_bytes(inputstr):
         value = round(value * 1048576)
     elif unit == 'KiB':
         value = round(value * 1024)
+    else:
+        exit_plugin(3, f'Unknown metric unit in "podman stats" output: {unit}', "")
 
     return int(value)
 


### PR DESCRIPTION
Docker and PodMan seem to be somewhat inconsistent with the way units in metrics are written.
This PR improves unit detection and will make the plugins result in an 3 - UNKNOWN if an unknown unit is detected.