### PR TITLE
Adapt to Python 3.14

### DIFF
--- a/.github/workflows/pycodestyle.yml
+++ b/.github/workflows/pycodestyle.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: ["3.14"]
     steps:
     - name: Check out repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: ["3.14"]
     steps:
     - name: Check out repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6

--- a/.github/workflows/python_unittests.yml
+++ b/.github/workflows/python_unittests.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
     - name: Check out repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6

--- a/check_container_stats_docker.py
+++ b/check_container_stats_docker.py
@@ -15,6 +15,7 @@
 
 import sys
 import socket
+import signal
 import time
 import json
 from re import match
@@ -65,6 +66,15 @@ def get_args() -> Arguments:
         args.socket = args.socket[7:]
 
     return args
+
+
+def handle_sigalrm(signum, frame):  # pylint: disable=unused-argument
+    """
+    Icinga/Nagios/Nrpe send the process control signal SIGALRM when the
+    configured plugin timeout is reached.
+    This function terminates the plugin gracefully.
+    """
+    exit_plugin(3, 'Plugin timeout reached - terminating...', '')
 
 
 def exit_plugin(returncode, output, perfdata):
@@ -369,6 +379,13 @@ def main():
 
     # Get Arguments
     args = get_args()
+
+    # Terminate gracefully when receiving SIGALRM
+    # (triggered by Icinga/Nagios/Nrpe when configured timeout is reached)
+    signal.signal(signal.SIGALRM, handle_sigalrm)
+
+    # Trigger SIGALRM after configured timeout is reached
+    signal.alarm(args.timeout)
 
     # Get daemon API version
     server_version: dict = send_http_get('/version', socketfile=args.socket)["http_response"]

--- a/check_container_stats_podman.py
+++ b/check_container_stats_podman.py
@@ -16,6 +16,7 @@
 
 import os
 import sys
+import signal
 import subprocess
 from re import findall, match
 from string import ascii_letters
@@ -54,6 +55,15 @@ def get_args():
                             type=int, dest='pidcrit')
     args = parser.parse_args()
     return args
+
+
+def handle_sigalrm(signum, frame):  # pylint: disable=unused-argument
+    """
+    Icinga/Nagios/Nrpe send the process control signal SIGALRM when the
+    configured plugin timeout is reached.
+    This function terminates the plugin gracefully.
+    """
+    exit_plugin(3, 'Plugin timeout reached - terminating...', '')
 
 
 def exit_plugin(returncode, output, perfdata):
@@ -207,6 +217,13 @@ def main():
 
     # Get Arguments
     args = get_args()
+
+    # Terminate gracefully when receiving SIGALRM
+    # (triggered by Icinga/Nagios/Nrpe when configured timeout is reached)
+    signal.signal(signal.SIGALRM, handle_sigalrm)
+
+    # Trigger SIGALRM after configured timeout is reached
+    signal.alarm(args.timeout)
 
     # environment variables for "docker" command
     docker_env = os.environ

--- a/check_docker_system.py
+++ b/check_docker_system.py
@@ -14,6 +14,7 @@
 
 import sys
 import socket
+import signal
 import time
 import json
 import asyncio
@@ -32,6 +33,11 @@ def get_args() -> Arguments:
 
     parser.add_argument(
         '--debug', dest='debug', action='store_true', help="Print debug information", default=False
+    )
+
+    parser.add_argument(
+        "-t", "--timeout", required=False, help="Plugin timeout in seconds", type=int,
+        dest='timeout', default=10
     )
 
     thresh = parser.add_argument_group('Thresholds')
@@ -53,6 +59,15 @@ def get_args() -> Arguments:
 
     args = parser.parse_args()
     return args
+
+
+def handle_sigalrm(signum, frame):  # pylint: disable=unused-argument
+    """
+    Icinga/Nagios/Nrpe send the process control signal SIGALRM when the
+    configured plugin timeout is reached.
+    This function terminates the plugin gracefully.
+    """
+    exit_plugin(3, 'Plugin timeout reached - terminating...', '')
 
 
 def send_socket_cmd(cmd: str, socketfile: str) -> str:
@@ -274,18 +289,22 @@ def exit_plugin(returncode: int, output: str, perfdata: str):
         sys.exit(0)
 
 
-def main():
+async def main():
     """ Main program code """
 
     args: Arguments = get_args()
 
+    # Terminate gracefully when receiving SIGALRM
+    # (triggered by Icinga/Nagios/Nrpe when configured timeout is reached)
+    signal.signal(signal.SIGALRM, handle_sigalrm)
+    # Trigger SIGALRM after configured timeout is reached
+    signal.alarm(args.timeout)
+
     # Get /info and /volumes from Docker socket
-    loop = asyncio.get_event_loop()
-    state, volumes = loop.run_until_complete(asyncio.gather(
+    state, volumes = await asyncio.gather(
         send_http_get('/info', socketfile=args.socket),
         send_http_get('/volumes', socketfile=args.socket),
-    ))
-    loop.close()
+    )
 
     # Check HTTP response code
     if state["http_status"] not in [200]:
@@ -344,4 +363,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/check_docker_system.py
+++ b/check_docker_system.py
@@ -363,4 +363,12 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    if sys.version_info >= (3, 7):
+        asyncio.run(main())
+    else:
+        # Retain backward compatibility with Python 3.6 as this is still the default Python version
+        # on EL8 platforms
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(main())
+        loop.close()

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -2,12 +2,49 @@
 
 import sys
 import unittest
+import unittest.mock
 
 sys.path.append('..')
 sys.path.append('.')
 
 import check_container_stats_docker
 import check_container_stats_podman
+import check_docker_system
+
+class TestScriptExecution(unittest.TestCase):
+    """
+    Test if main() function of non-async plugins executes without exception and performs clean exit
+    """
+
+    def test_check_container_stats_docker_help(self):
+        with unittest.mock.patch('sys.argv', ['check_container_stats_docker.py', '--help']):
+            with self.assertRaises(SystemExit) as exit_code:
+                check_container_stats_docker.main()
+
+            # Test if exit code was 0
+            self.assertEqual(exit_code.exception.code, 0)
+
+    def test_check_container_stats_podman_help(self):
+        with unittest.mock.patch('sys.argv', ['check_container_stats_podman.py', '--help']):
+            with self.assertRaises(SystemExit) as exit_code:
+                check_container_stats_podman.main()
+
+            # Test if exit code was 0
+            self.assertEqual(exit_code.exception.code, 0)
+
+
+class TestAsyncScriptExecution(unittest.IsolatedAsyncioTestCase):
+    """
+    Test if main() function of async plugins executes without exception and performs clean exit
+    """
+
+    async def test_check_docker_system_help(self):
+        with unittest.mock.patch('sys.argv', ['check_docker_system.py', '--help']):
+            with self.assertRaises(SystemExit) as exit_code:
+                await check_docker_system.main()
+
+            # Test if exit code was 0
+            self.assertEqual(exit_code.exception.code, 0)
 
 
 class TestMetricDetection(unittest.TestCase):


### PR DESCRIPTION
- Adapt plugins to Python 3.14 (`asyncio` handling) 
  fixes #11 
- Add handlers for `SIGALRM`
- Improve unit tests
- (chores): bump GitHub action versions

